### PR TITLE
Remove deprecated https listener references and centralize HTTP ingress

### DIFF
--- a/src/main/mule/global.xml
+++ b/src/main/mule/global.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<mule xmlns:tls="http://www.mulesoft.org/schema/mule/tls"
-	xmlns:spring="http://www.mulesoft.org/schema/mule/spring"
+<mule xmlns:spring="http://www.mulesoft.org/schema/mule/spring"
 	xmlns:apikit="http://www.mulesoft.org/schema/mule/mule-apikit"
 	xmlns:http="http://www.mulesoft.org/schema/mule/http"
 	xmlns="http://www.mulesoft.org/schema/mule/core"
@@ -11,23 +10,14 @@
 http://www.mulesoft.org/schema/mule/mule-apikit http://www.mulesoft.org/schema/mule/mule-apikit/current/mule-apikit.xsd 
 http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
 http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-http://www.mulesoft.org/schema/mule/spring http://www.mulesoft.org/schema/mule/spring/current/mule-spring.xsd
-http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/current/mule-tls.xsd">
+http://www.mulesoft.org/schema/mule/spring http://www.mulesoft.org/schema/mule/spring/current/mule-spring.xsd">
 	
 	<configuration-properties doc:name="Properties Config" file="properties.yaml" />
 		
 	<http:listener-config name="http">
         <http:listener-connection host="0.0.0.0" port="${httpPort}" />
     </http:listener-config>
-    
-    <http:listener-config name="https">
-        <http:listener-connection host="0.0.0.0" port="${httpsPort}" protocol="HTTPS">
-			<tls:context >
-				<tls:key-store type="jceks" path="server.jceks" alias="self-signed-certificate" keyPassword="selfsigned" password="selfsigned" />
-			</tls:context>
-		</http:listener-connection>
-    </http:listener-config>
-    
+
     <apikit:config name="net-tools-config" raml="net-tools.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
     
     <spring:config name="Spring_Config" doc:id="45181472-36fd-44e6-b710-296481c3c450" files="beans.xml" />

--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -13,9 +13,6 @@ http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mul
 http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 
 	<flow name="ui" doc:id="94b97777-bd63-4abb-8093-a5c8ac97aa17">
-		<http:listener doc:name="Listener"
-			doc:id="7e20b485-577c-4530-b2b1-66b6a84d5694" config-ref="https"
-			path="/*" outputMimeType="text/html" />
 		<http:basic-security-filter
 			doc:name="Basic security filter"
 			doc:id="cb77f47e-923a-4195-86fc-23bbf2f01311" realm="mule" />
@@ -54,17 +51,6 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	</flow>
 	<flow name="net-tools-main"
 		doc:id="6f86a93f-9de9-4cf8-b092-b6a4b23c42f4">
-		<http:listener config-ref="https" path="/api/*">
-			<http:response
-				statusCode="#[vars.httpStatus default 200]">
-				<http:headers>#[vars.outboundHeaders default {}]</http:headers>
-			</http:response>
-			<http:error-response
-				statusCode="#[vars.httpStatus default 500]">
-				<http:body>#[payload]</http:body>
-				<http:headers>#[vars.outboundHeaders default {}]</http:headers>
-			</http:error-response>
-		</http:listener>
 		<http:basic-security-filter doc:name="Basic security filter" realm="mule" />
 		<logger level="INFO"
 			message='#["$(attributes.scheme default "") $(attributes.method default "") $(attributes.requestUri default "")"]'


### PR DESCRIPTION
### Motivation

- Consolidate HTTP ingress to the existing `http` listener definitions in `http.xml` and remove duplicate/unused `https` listener wiring from flows and global config.
- Remove unused TLS/HTTPS configuration to avoid confusion and make the API entrypoint consistent across modules.

### Description

- Removed the `<http:listener ... config-ref="https" .../>` from the `flow name="ui"` in `src/main/mule/net-tools.xml` so UI ingress is handled by `http.xml`'s `http-ui` flow.
- Removed the `<http:listener config-ref="https" path="/api/*">` block at the start of `flow name="net-tools-main"` in `src/main/mule/net-tools.xml` so API routing is performed via `http.xml`'s `http-net-tools-main` flow.
- Removed the `http:listener-config name="https"` block and the unused `tls` namespace/schemaLocation entries from `src/main/mule/global.xml`.
- Updated `global.xml` schemaLocation to remove the TLS schema and ensured the `http` listener-config remains for the centralized ingress.

### Testing

- Ran `rg -n 'config-ref="https"' src/main/mule` to verify there are zero remaining `https` references, which succeeded.
- Inspected `src/main/mule/http.xml` and `src/main/mule/net-tools.xml` with `nl`/`sed` and `rg` to confirm `config-ref="http"` is used for both UI (`/*`) and API (`/api/*`) ingress, which succeeded.
- Verified repository status to confirm the intended files were modified, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1440f15b4832a9551d366a2a5052e)