### PR TITLE
Consolidate Mule HTTP listeners into single entry flow

### DIFF
--- a/src/main/mule/http.xml
+++ b/src/main/mule/http.xml
@@ -7,27 +7,25 @@
 	xsi:schemaLocation="
 	http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
 	
-	<flow name="http-ui" doc:id="26329426-60ba-49ad-ae04-ac3bfb607dea" initialState="${httpListener}">
+	<flow name="http-entrypoint" doc:id="26329426-60ba-49ad-ae04-ac3bfb607dea" initialState="${httpListener}">
 		<http:listener doc:name="Listener"
 			doc:id="945b4a80-dcdd-460e-a520-24f510d84be8" config-ref="http"
-			path="/*" outputMimeType="text/html" />
-		<flow-ref doc:name="ui"
-			doc:id="e74273e3-e138-414c-b6bf-58728820b208" name="ui" />
-	</flow>
-
-	<flow name="http-net-tools-main" initialState="${httpListener}">
-		<http:listener config-ref="http" path="/api/*">
-			<http:response
-				statusCode="#[vars.httpStatus default 200]">
+			path="/*" outputMimeType="text/html">
+			<http:response statusCode="#[vars.httpStatus default 200]">
 				<http:headers>#[vars.outboundHeaders default {}]</http:headers>
 			</http:response>
-			<http:error-response
-				statusCode="#[vars.httpStatus default 500]">
+			<http:error-response statusCode="#[vars.httpStatus default 500]">
 				<http:body>#[payload]</http:body>
 				<http:headers>#[vars.outboundHeaders default {}]</http:headers>
 			</http:error-response>
 		</http:listener>
-		<flow-ref doc:name="net-tools-main" doc:id="7b7d5435-a4ae-4c67-9159-cf238285bd32" name="net-tools-main"/>
-	
-</flow>
+		<choice doc:name="Route request by path">
+			<when expression='#[attributes.requestPath startsWith "/api/"]'>
+				<flow-ref doc:name="net-tools-main" doc:id="7b7d5435-a4ae-4c67-9159-cf238285bd32" name="net-tools-main" />
+			</when>
+			<otherwise>
+				<flow-ref doc:name="ui" doc:id="e74273e3-e138-414c-b6bf-58728820b208" name="ui" />
+			</otherwise>
+		</choice>
+	</flow>
 </mule>

--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -13,9 +13,6 @@ http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mul
 http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
 
 	<flow name="ui" doc:id="94b97777-bd63-4abb-8093-a5c8ac97aa17">
-		<http:listener doc:name="Listener"
-			doc:id="7e20b485-577c-4530-b2b1-66b6a84d5694" config-ref="https"
-			path="/*" outputMimeType="text/html" />
 		<http:basic-security-filter
 			doc:name="Basic security filter"
 			doc:id="cb77f47e-923a-4195-86fc-23bbf2f01311" realm="mule" />
@@ -54,17 +51,6 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	</flow>
 	<flow name="net-tools-main"
 		doc:id="6f86a93f-9de9-4cf8-b092-b6a4b23c42f4">
-		<http:listener config-ref="https" path="/api/*">
-			<http:response
-				statusCode="#[vars.httpStatus default 200]">
-				<http:headers>#[vars.outboundHeaders default {}]</http:headers>
-			</http:response>
-			<http:error-response
-				statusCode="#[vars.httpStatus default 500]">
-				<http:body>#[payload]</http:body>
-				<http:headers>#[vars.outboundHeaders default {}]</http:headers>
-			</http:error-response>
-		</http:listener>
 		<http:basic-security-filter doc:name="Basic security filter" realm="mule" />
 		<logger level="INFO"
 			message='#["$(attributes.scheme default "") $(attributes.method default "") $(attributes.requestUri default "")"]'


### PR DESCRIPTION
### Motivation
- Centralize inbound HTTP handling by merging `http-ui` and `http-net-tools-main` so a single flow owns the `http:listener` and response handling. 
- Route requests after the single listener to either the UI or API to simplify configuration and avoid duplicate listeners.

### Description
- Merged the two entry flows into a single flow `http-entrypoint` in `src/main/mule/http.xml` and set the listener to `path="/*"` with unified `http:response`/`http:error-response` handling. 
- Added a `choice` router that checks `attributes.requestPath` and forwards requests starting with `/api/` to the `net-tools-main` flow and all others to the `ui` flow. 
- Removed all `<http:listener>` elements from flows in `src/main/mule/net-tools.xml` so inbound responsibility is fixed in `http.xml`. 
- Left listener configuration entries in `src/main/mule/global.xml` unchanged.

### Testing
- Ran `rg -n "<http:listener" src/main/mule` and confirmed only one `http:listener` remains in `src/main/mule/http.xml`, which succeeded. 
- Inspected the modified files with `nl`/`sed` to verify the presence of `http-entrypoint`, the `choice` router, and removal of listener blocks from `net-tools.xml`, which matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f144534a94832ab929e5fe562b1b8b)