### PR TITLE
Refactor APIKit routes to a single api-dispatch flow

### DIFF
--- a/src/main/mule/global.xml
+++ b/src/main/mule/global.xml
@@ -28,7 +28,16 @@ http://www.mulesoft.org/schema/mule/tls http://www.mulesoft.org/schema/mule/tls/
 		</http:listener-connection>
     </http:listener-config>
     
-    <apikit:config name="net-tools-config" raml="net-tools.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
+    <apikit:config name="net-tools-config" raml="net-tools.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus">
+        <apikit:flow-mapping resource="/ping" action="get" flow-ref="api-dispatch" />
+        <apikit:flow-mapping resource="/dns" action="get" flow-ref="api-dispatch" />
+        <apikit:flow-mapping resource="/curl" action="get" flow-ref="api-dispatch" />
+        <apikit:flow-mapping resource="/curl" action="post" flow-ref="api-dispatch" content-type="text/plain" />
+        <apikit:flow-mapping resource="/socket" action="get" flow-ref="api-dispatch" />
+        <apikit:flow-mapping resource="/certest" action="get" flow-ref="api-dispatch" />
+        <apikit:flow-mapping resource="/ciphertest" action="get" flow-ref="api-dispatch" />
+        <apikit:flow-mapping resource="/traceroute" action="get" flow-ref="api-dispatch" />
+    </apikit:config>
     
     <spring:config name="Spring_Config" doc:id="45181472-36fd-44e6-b710-296481c3c450" files="beans.xml" />
 	<spring:security-manager> 

--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -151,94 +151,97 @@ output application/json
             </on-error-propagate>
         </error-handler>
     </flow>
-	<flow name="get:\curl:net-tools-config">
-		<ee:transform doc:name="Transform Message" doc:id="c96eaddb-f56e-4f1a-81ff-ec15df7cb6d6" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-    </flow>
-    <flow name="post:\curl:text\plain:net-tools-config">
-		<ee:transform doc:name="Transform Message" doc:id="66977d21-487a-4048-a615-ba8ca9208f33" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean, payload)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-    </flow>
-    <flow name="get:\dns:net-tools-config">
-        <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="2eb37294-21d7-412a-8ab6-8da73008b111">
-            <ee:message>
-                <ee:set-payload><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::resolveIPs(attributes.queryParams.host, attributes.queryParams.dnsServer default "")]]></ee:set-payload>
-            </ee:message>
-        </ee:transform>
-    </flow>
-    <flow name="get:\ping:net-tools-config">
-		<ee:transform doc:name="Transform Message" doc:id="4042b6d3-cc6a-4fae-ae4c-ea39b6650dbe" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
+
+	<flow name="api-dispatch">
+		<choice>
+			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/ping"]'>
+				<ee:transform doc:name="Ping">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
 NetworkUtils::ping(attributes.queryParams.host)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-    </flow>
-    <flow name="get:\socket:net-tools-config">
-        <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="38147a29-0fe5-47f2-ba74-135f9392ecd3">
-            <ee:message>
-                <ee:set-payload><![CDATA[%dw 2.0
+					</ee:message>
+				</ee:transform>
+			</when>
+			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/dns"]'>
+				<ee:transform doc:name="DNS">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::testConnect(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
-            </ee:message>
-        </ee:transform>
-    </flow>
-    <flow name="get:\certest:net-tools-config" doc:id="8e725dad-59c4-4713-9771-91a850e9ce9d" >
-		<ee:transform doc:name="Transform Message" doc:id="70af9c23-b034-40fc-ab42-7781c55b85e3" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
+NetworkUtils::resolveIPs(attributes.queryParams.host, attributes.queryParams.dnsServer default "")]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/curl"]'>
+				<ee:transform doc:name="Curl GET">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::certest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-	</flow>
-	<flow name="get:\ciphertest:net-tools-config" doc:id="349ff8fc-6032-4d79-85c9-5d0c4a59e035" >
-		<ee:transform doc:name="Transform Message" doc:id="690960a8-0545-4d52-ab77-c170ff06a27d" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
+NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean)]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/api/curl"]'>
+				<ee:transform doc:name="Curl POST">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::cipherTest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-	</flow>
-	<flow name="get:\traceroute:net-tools-config">
-        <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="
-http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd 
-http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="a006967e-8161-45f9-af3b-d1f3386ae267">
-            <ee:message>
-                <ee:set-payload><![CDATA[%dw 2.0
+NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean, payload)]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/traceroute"]'>
+				<ee:transform doc:name="Traceroute">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
 NetworkUtils::traceRoute(attributes.queryParams.host)]]></ee:set-payload>
-            </ee:message>
-        </ee:transform>
-    </flow>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/certest"]'>
+				<ee:transform doc:name="Certest">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/java
+import java!com::mulesoft::tool::network::NetworkUtils
+---
+NetworkUtils::certest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/ciphertest"]'>
+				<ee:transform doc:name="CipherTest">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/java
+import java!com::mulesoft::tool::network::NetworkUtils
+---
+NetworkUtils::cipherTest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/socket"]'>
+				<ee:transform doc:name="Socket">
+					<ee:message>
+						<ee:set-payload><![CDATA[%dw 2.0
+output application/java
+import java!com::mulesoft::tool::network::NetworkUtils
+---
+NetworkUtils::testConnect(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
+					</ee:message>
+				</ee:transform>
+			</when>
+		</choice>
+	</flow>
 </mule>


### PR DESCRIPTION
### Motivation
- Simplify APIKit routing by consolidating per-endpoint implementation flows into a single dispatch flow so Router always forwards to one flow for easier maintenance and unified dispatch logic.
- Preserve existing runtime behavior and existing DataWeave/Java processing while centralizing request routing logic.

### Description
- Added `apikit:flow-mapping` entries in `src/main/mule/global.xml` so all RAML resources/actions map to a single `flow-ref="api-dispatch"` target for `/ping`, `/dns`, `/curl` (GET/POST), `/socket`, `/certest`, `/ciphertest`, and `/traceroute`.
- Removed the old per-endpoint APIKit flows from `src/main/mule/net-tools.xml` and introduced a single `flow name="api-dispatch"` that uses a `choice` on `attributes.method` and `attributes.requestPath` to route to the appropriate branch.
- Reused existing DataWeave/Java calls unchanged inside each `choice` branch (calls to `NetworkUtils::ping`, `resolveIPs`, `curl`, `traceRoute`, `certest`, `cipherTest`, `testConnect`).
- Left the `net-tools-main` `apikit:router` usage and the existing APIKIT error handling blocks intact so error semantics remain unchanged.

### Testing
- Ran `rg -n "<flow name=\"(get:|post:)|flow-ref=\"api-dispatch\"|apikit:router|<flow name=\"api-dispatch\"" src/main/mule/net-tools.xml src/main/mule/global.xml` to confirm all APIKit mappings now point to `api-dispatch` and legacy scaffolded flows are removed, which succeeded.
- Inspected the modified files with `nl -ba src/main/mule/net-tools.xml` and `nl -ba src/main/mule/global.xml` to verify the new `api-dispatch` flow contents and the `apikit:flow-mapping` entries, which succeeded.
- Attempted XML validation with `xmllint --noout src/main/mule/net-tools.xml src/main/mule/global.xml` but the environment lacks `xmllint`, so structural validation was not performed due to the missing tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f144579358832ab46cfa41a7f4b944)