### PR TITLE
Consolidate net-tools API into single /tools dispatch

### DIFF
--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -151,94 +151,29 @@ output application/json
             </on-error-propagate>
         </error-handler>
     </flow>
-	<flow name="get:\curl:net-tools-config">
-		<ee:transform doc:name="Transform Message" doc:id="c96eaddb-f56e-4f1a-81ff-ec15df7cb6d6" >
+	<flow name="post:\tools:application\json:net-tools-config">
+		<ee:transform doc:name="Transform Message" doc:id="single-dispatch-tools" >
 			<ee:message >
 				<ee:set-payload ><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
+var req = payload
 ---
-NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean)]]></ee:set-payload>
+(req.operation default "") match {
+  case "ping" -> NetworkUtils::ping(req.host)
+  case "dns" -> NetworkUtils::resolveIPs(req.host, req.dnsServer default "")
+  case "curl" ->
+    if ((req.payload default null) != null)
+      NetworkUtils::curl(req.url, req.header default [], req.insecure default false, req.payload)
+    else
+      NetworkUtils::curl(req.url, req.header default [], req.insecure default false)
+  case "socket" -> NetworkUtils::testConnect(req.host, req.port)
+  case "traceroute" -> NetworkUtils::traceRoute(req.host)
+  case "certest" -> NetworkUtils::certest(req.host, req.port)
+  case "ciphertest" -> NetworkUtils::cipherTest(req.host, req.port)
+  else -> "Unsupported operation: " ++ (req.operation default "")
+}]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
-    </flow>
-    <flow name="post:\curl:text\plain:net-tools-config">
-		<ee:transform doc:name="Transform Message" doc:id="66977d21-487a-4048-a615-ba8ca9208f33" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean, payload)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-    </flow>
-    <flow name="get:\dns:net-tools-config">
-        <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="2eb37294-21d7-412a-8ab6-8da73008b111">
-            <ee:message>
-                <ee:set-payload><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::resolveIPs(attributes.queryParams.host, attributes.queryParams.dnsServer default "")]]></ee:set-payload>
-            </ee:message>
-        </ee:transform>
-    </flow>
-    <flow name="get:\ping:net-tools-config">
-		<ee:transform doc:name="Transform Message" doc:id="4042b6d3-cc6a-4fae-ae4c-ea39b6650dbe" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::ping(attributes.queryParams.host)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-    </flow>
-    <flow name="get:\socket:net-tools-config">
-        <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="38147a29-0fe5-47f2-ba74-135f9392ecd3">
-            <ee:message>
-                <ee:set-payload><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::testConnect(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
-            </ee:message>
-        </ee:transform>
-    </flow>
-    <flow name="get:\certest:net-tools-config" doc:id="8e725dad-59c4-4713-9771-91a850e9ce9d" >
-		<ee:transform doc:name="Transform Message" doc:id="70af9c23-b034-40fc-ab42-7781c55b85e3" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::certest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-	</flow>
-	<flow name="get:\ciphertest:net-tools-config" doc:id="349ff8fc-6032-4d79-85c9-5d0c4a59e035" >
-		<ee:transform doc:name="Transform Message" doc:id="690960a8-0545-4d52-ab77-c170ff06a27d" >
-			<ee:message >
-				<ee:set-payload ><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::cipherTest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
-			</ee:message>
-		</ee:transform>
-	</flow>
-	<flow name="get:\traceroute:net-tools-config">
-        <ee:transform xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xsi:schemaLocation="
-http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd 
-http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="a006967e-8161-45f9-af3b-d1f3386ae267">
-            <ee:message>
-                <ee:set-payload><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::traceRoute(attributes.queryParams.host)]]></ee:set-payload>
-            </ee:message>
-        </ee:transform>
     </flow>
 </mule>

--- a/src/main/resources/api/net-tools.raml
+++ b/src/main/resources/api/net-tools.raml
@@ -6,148 +6,118 @@ securitySchemes:
   basic:
     type: Basic Authentication
 
-/ping:
-  get:
-    description: Runs an ICMP test from the Mule host to the specified endpoint
-    queryParameters:
-      host:
-        description: The domain or ip of the host to ping
-        type: string
-    responses: 
-      200:
-        body: 
-          text/plain:
-            example: |
-              PING localhost (127.0.0.1): 56 data bytes
-              64 bytes from 127.0.0.1: icmp_seq=0 ttl=64 time=0.050 ms
-              64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.070 ms
-              64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.054 ms
-              64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=0.046 ms
+types:
+  ToolOperation:
+    type: string
+    enum: [ping, dns, curl, socket, traceroute, certest, ciphertest]
 
-              --- localhost ping statistics ---
-              4 packets transmitted, 4 packets received, 0.0% packet loss
-              round-trip min/avg/max/stddev = 0.046/0.055/0.070/0.009 ms
-
-/socket:
-  get:
-    description: Creates a TCP socket to test connectivity to an IP:Port combination
-    queryParameters:
-      host:
-        description: The domain or ip of the host to be tested
+  ToolRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      operation:
+        type: ToolOperation
+        description: Operation type selector.
+      host?:
         type: string
-      port:
-        description: The port number of host to be tested
+        description: Required for ping, dns, socket, traceroute, certest, ciphertest.
+      port?:
         type: number
-    responses: 
-      200:
-        body: 
-          text/plain:
-            example: |
-              Connectivity is successful
-/traceroute:
-  get:
-    description: Runs a traceroute test from the Mule host to the specified endpoint
-    queryParameters:
-      host:
-        description: The domain or ip of the host to traceroute
+        description: Required for socket, certest, ciphertest.
+      url?:
         type: string
-    responses: 
-      200:
-        body: 
-          text/plain:
-            example: |
-               1  216.182.237.132  1.203 ms 216.182.237.128  1.185 ms 216.182.237.132  1.681 ms
-               2  100.64.1.13  1.671 ms 100.64.1.235  1.337 ms 100.64.1.205  1.649 ms
-               3  100.64.0.184  469.084 ms 100.64.0.210  992.624 ms 100.64.0.216  1012.502 ms
-               4  100.64.16.43  0.777 ms 100.64.16.47  0.940 ms 100.64.16.91  0.904 ms
-               5  72.21.222.221  1.588 ms 72.21.222.223  1.561 ms 72.21.222.221  1.581 ms
-               6  54.240.242.42  12.569 ms 54.240.243.142  3.572 ms 54.240.242.102  18.003 ms
-               7  54.240.243.93  1.225 ms 54.240.242.13  1.249 ms  1.244 ms
-               8  52.95.216.113  1.092 ms  0.878 ms  0.972 ms
-               9  216.239.50.189  1.963 ms 216.239.54.205  2.139 ms 216.239.49.9  1.962 ms
-               10  216.239.58.213  2.424 ms 64.233.174.43  2.246 ms 216.239.58.215  1.577 ms
-               11  8.8.8.8  1.824 ms  1.383 ms  1.339 ms
-/dns:
-  get:
-    description: Resolves the specified endpoint's IP using the hosts DNS servers
-    queryParameters:
-      host:
-        description: The the fully qualified domain name the host to test
+        description: Required for curl.
+      header?:
+        type: array
+        items: string
+        description: Optional request headers used by curl.
+      dnsServer?:
         type: string
-      dnsServer:
-        description: The DNS server to use for resolution.        
+        description: Optional DNS server used by dns.
+      insecure?:
+        type: boolean
+        description: Optional curl TLS verification flag.
+      payload?:
         type: string
-        required: false
-    responses: 
-      200:
-        body: 
-          text/plain:
-            example: |
-               127.0.0.1
-/curl:
-  get:
-    description: Runs a curl from the Mule host to the specified resource
-    queryParameters:
-      url:
-        description: Target URL
-        type: string 
-      header:
-        required: false
-        items:
-          type: string
-          example: |
-            Authorization:Basic YQxhZGRpbjpvcGVuc2VzYW1l
-    responses: 
-      200:
-        body: 
-          text/plain:
-            example: |
-              curl: (7) Failed to connect to 10.200.27.15 port 443: Timed out             
+        description: Optional payload used by curl.
+    required: [operation]
+    examples:
+      ping:
+        value:
+          operation: ping
+          host: localhost
+      dns:
+        value:
+          operation: dns
+          host: example.com
+          dnsServer: 8.8.8.8
+      curl:
+        value:
+          operation: curl
+          url: https://example.com
+          header:
+            - Authorization:Basic YQxhZGRpbjpvcGVuc2VzYW1l
+          insecure: false
+          payload: '{"message":"hello"}'
+      socket:
+        value:
+          operation: socket
+          host: 127.0.0.1
+          port: 443
+      traceroute:
+        value:
+          operation: traceroute
+          host: 8.8.8.8
+      certest:
+        value:
+          operation: certest
+          host: example.com
+          port: 443
+      ciphertest:
+        value:
+          operation: ciphertest
+          host: example.com
+          port: 443
+
+/tools:
   post:
-    description: Runs a curl(POST) from the Mule host to the specified resource 
-    queryParameters:
-      url:
-        description: Target URL
-        type: string 
-      header:
-        required: false
-        items:
-          type: string
-          example: |
-            Authorization:Basic YQxhZGRpbjpvcGVuc2VzYW1l
+    description: |
+      Runs a selected network tool operation from the Mule host.
+      Required fields by operation:
+      - ping: host
+      - dns: host (dnsServer optional)
+      - curl: url (header/insecure/payload optional)
+      - socket: host, port
+      - traceroute: host
+      - certest: host, port
+      - ciphertest: host, port
     body:
-      text/plain:
-        description: Payload
-        type: string 
-
-/ciphertest:
-  get:
-    description: Checks available SSL cipher suites for a given endpoint
-    queryParameters:
-      host:
-        description: The domain or ip of the host to connect to
-        type: string
-      port:
-        description: The port number of host to be tested
-        type: number        
-    responses: 
+      application/json:
+        type: ToolRequest
+    responses:
       200:
-        body: 
+        body:
           text/plain:
-            example: List of supported ciphers...
-
-/certest:
-  get:
-    description: Runs an SSL connection and pulls the certificates found
-    queryParameters:
-      host:
-        description: The domain or ip of the host to connect to
-        type: string
-      port:
-        description: The port number of host to be tested
-        type: number        
-    responses: 
-      200:
-        body: 
-          text/plain:
-            example: CONNECTED(00000005)
+            examples:
+              ping:
+                value: |
+                  PING localhost (127.0.0.1): 56 data bytes
+                  64 bytes from 127.0.0.1: icmp_seq=0 ttl=64 time=0.050 ms
+              dns:
+                value: |
+                  127.0.0.1
+              curl:
+                value: |
+                  curl: (7) Failed to connect to 10.200.27.15 port 443: Timed out
+              socket:
+                value: |
+                  Connectivity is successful
+              traceroute:
+                value: |
+                  1  216.182.237.132  1.203 ms
+              certest:
+                value: |
+                  CONNECTED(00000005)
+              ciphertest:
+                value: |
+                  List of supported ciphers...


### PR DESCRIPTION
### Motivation
- Reduce API surface by exposing one canonical `/tools` endpoint that selects the operation via an `operation` discriminator instead of multiple per-tool paths.
- Unify input shapes for all tools so required parameters are validated per-operation and to prevent APIKit from regenerating many per-resource flows.
- Simplify runtime wiring so the implementation connects to a single dispatch flow and avoids duplicate/legacy flows after APIKit regeneration.

### Description
- Replaced multiple RAML resources with a single `POST /tools` in `src/main/resources/api/net-tools.raml` and added a `ToolRequest` type with an `operation` enum and consolidated fields (`host`, `port`, `url`, `header`, `dnsServer`, `insecure`, `payload`).
- Documented per-operation required fields in the `/tools` `description` and added operation-specific request examples and response `examples` under the single endpoint.
- Replaced the many per-resource APIKit flows in `src/main/mule/net-tools.xml` with one dispatch flow `post:\tools:application\json:net-tools-config` that runs a DataWeave match on `payload.operation` and calls the appropriate `NetworkUtils` function.
- Removed legacy flows such as `get:\ping:*`, `get:\dns:*`, `get:\curl:*`, etc., and introduced the `single-dispatch-tools` transform which performs the runtime dispatch.

### Testing
- Ran a repository grep to confirm legacy per-resource flows are no longer present in `src/main/mule/net-tools.xml`, which succeeded.
- Ran `mvn -q -DskipTests package` to validate the build, which failed in this environment due to unresolved external `org.mule.tools.maven:mule-maven-plugin:4.5.0` dependencies and not because of the RAML/XML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1445b567c832ab7f452e8157b947d)