### PR TITLE
Align API implementation and UI with /tools POST contract

### DIFF
--- a/src/main/mule/http.xml
+++ b/src/main/mule/http.xml
@@ -20,7 +20,7 @@
 			</http:error-response>
 		</http:listener>
 		<choice doc:name="Route request by path">
-			<when expression='#[attributes.requestPath startsWith "/api/"]'>
+			<when expression='#[attributes.requestPath startsWith "/api/" or attributes.requestPath == "/tools"]'>
 				<flow-ref doc:name="net-tools-main" doc:id="7b7d5435-a4ae-4c67-9159-cf238285bd32" name="net-tools-main" />
 			</when>
 			<otherwise>

--- a/src/main/mule/net-tools.xml
+++ b/src/main/mule/net-tools.xml
@@ -140,92 +140,80 @@ output application/json
 
 	<flow name="api-dispatch">
 		<choice>
-			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/ping"]'>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/tools" and payload.operation == "ping"]'>
 				<ee:transform doc:name="Ping">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
-var req = payload
 ---
-NetworkUtils::ping(attributes.queryParams.host)]]></ee:set-payload>
+NetworkUtils::ping(payload.host)]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</when>
-			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/dns"]'>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/tools" and payload.operation == "dns"]'>
 				<ee:transform doc:name="DNS">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::resolveIPs(attributes.queryParams.host, attributes.queryParams.dnsServer default "")]]></ee:set-payload>
+NetworkUtils::resolveIPs(payload.host, payload.dnsServer default "")]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</when>
-			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/curl"]'>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/tools" and payload.operation == "curl"]'>
 				<ee:transform doc:name="Curl GET">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean)]]></ee:set-payload>
+NetworkUtils::curl(payload.url, payload.header default [], payload.insecure default false, payload.payload default "")]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</when>
-			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/api/curl"]'>
-				<ee:transform doc:name="Curl POST">
-					<ee:message>
-						<ee:set-payload><![CDATA[%dw 2.0
-output application/java
-import java!com::mulesoft::tool::network::NetworkUtils
----
-NetworkUtils::curl(attributes.queryParams.url, attributes.queryParams.*header default [], attributes.queryParams.insecure as Boolean, payload)]]></ee:set-payload>
-					</ee:message>
-				</ee:transform>
-			</when>
-			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/traceroute"]'>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/tools" and payload.operation == "traceroute"]'>
 				<ee:transform doc:name="Traceroute">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::traceRoute(attributes.queryParams.host)]]></ee:set-payload>
+NetworkUtils::traceRoute(payload.host)]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</when>
-			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/certest"]'>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/tools" and payload.operation == "certest"]'>
 				<ee:transform doc:name="Certest">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::certest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
+NetworkUtils::certest(payload.host, payload.port)]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</when>
-			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/ciphertest"]'>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/tools" and payload.operation == "ciphertest"]'>
 				<ee:transform doc:name="CipherTest">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::cipherTest(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
+NetworkUtils::cipherTest(payload.host, payload.port)]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</when>
-			<when expression='#[attributes.method == "GET" and attributes.requestPath == "/api/socket"]'>
+			<when expression='#[attributes.method == "POST" and attributes.requestPath == "/tools" and payload.operation == "socket"]'>
 				<ee:transform doc:name="Socket">
 					<ee:message>
 						<ee:set-payload><![CDATA[%dw 2.0
 output application/java
 import java!com::mulesoft::tool::network::NetworkUtils
 ---
-NetworkUtils::testConnect(attributes.queryParams.host, attributes.queryParams.port)]]></ee:set-payload>
+NetworkUtils::testConnect(payload.host, payload.port)]]></ee:set-payload>
 					</ee:message>
 				</ee:transform>
 			</when>

--- a/src/main/resources/web/index.html
+++ b/src/main/resources/web/index.html
@@ -283,8 +283,7 @@
                 $("#check").click(function() {
                     var operation = $("#operation").val();
                     var ip = $("#ip").val();
-					var method = "GET";
-					var body = null;
+                    var body = null;
                     var url = (operation === 'curl') ? $("#url").val() : '';
                     var port = (operation === 'socket' || operation === 'certest' || operation === 'ciphertest') ? $("#port").val() : '';
                     var dnsServer = (operation === 'dns') ? $("#dnsServer").val() : '';                    
@@ -303,22 +302,23 @@
                         console.error('Missing url!');
                         return;
                     }
-                    var apiurl = 'api/' + operation + '?host=' + ip;
-                    if (operation === 'socket' || operation === 'certest' || operation === 'ciphertest') {
-                        apiurl += '&port=' + port;
+                    var apiurl = 'tools';
+                    var requestBody = { operation: operation };
+                    if (operation !== 'curl') {
+                        requestBody.host = ip;
                     }
-                    if (operation === 'dns') {
-                        apiurl += '&dnsServer=' + dnsServer;
+                    if (operation === 'socket' || operation === 'certest' || operation === 'ciphertest') {
+                        requestBody.port = Number(port);
+                    }
+                    if (operation === 'dns' && dnsServer) {
+                        requestBody.dnsServer = dnsServer;
                     }
                     if (operation === 'curl') {
-                        apiurl += '&url=' + encodeURI(url);
-                        apiurl += '&insecure=' + $("#insecure").prop('checked');
-                        for (let h of $("#headers").val().split('\n')) {
-                        	apiurl += '&header=' + encodeURI(h);
-                        }
-                        method = $("#method").val();
-                        if(method === 'POST') {
-                        	body = $("#body").val();
+                        requestBody.url = url;
+                        requestBody.insecure = $("#insecure").prop('checked');
+                        requestBody.header = $("#headers").val().split('\n').filter(Boolean);
+                        if ($("#method").val() === 'POST') {
+                            requestBody.payload = $("#body").val();
                         }
                     }
                     console.log(operation + " " + ip + " " + port + " " + url );
@@ -326,9 +326,9 @@
                     $("#output").append('<pre class="command">&gt; ' + operation + ' ' + ip + ' ' + port + ' ' + url + '</pre>');
                     $.ajax({
                         url: apiurl,
-                        type: method,
-                        contentType: "text/plain",
-                        data: body
+                        type: "POST",
+                        contentType: "application/json",
+                        data: JSON.stringify(requestBody)
                     })
                     .done(function(result) {
                         if (operation === 'curl') {


### PR DESCRIPTION
### Motivation
- The RAML defines a single aggregated `POST /tools` API but the runtime was still routing to the legacy `/api/*` querystring endpoints, causing a spec/implementation mismatch.
- The UI still invoked `api/<operation>?...` endpoints instead of sending the consolidated JSON `POST /tools` payload, so client and server behavior were inconsistent.

### Description
- Updated `src/main/mule/http.xml` to route requests to `net-tools-main` when `attributes.requestPath == "/tools"` so `/tools` reaches the API flow.
- Reworked `src/main/mule/net-tools.xml` `api-dispatch` flow to dispatch on `POST /tools` and branch on `payload.operation`, and to pass parameters from the JSON body (`payload.host`, `payload.port`, `payload.url`, etc.) into each `NetworkUtils` invocation.
- Updated `src/main/resources/web/index.html` to build and `POST` a JSON `requestBody` to `tools` (setting `operation` and the required fields) and to use `contentType:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16427d488832a93bdeffcde3eefc6)