### PR TITLE
Add mule-public pluginRepository entry to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,10 @@
 	</repositories>
 	<pluginRepositories>
 		<pluginRepository>
+			<id>mule-public</id>
+			<url>https://repository.mulesoft.org/nexus/content/repositories/releases</url>
+		</pluginRepository>
+		<pluginRepository>
 			<id>mulesoft-releases</id>
 			<name>mulesoft release repository</name>
 			<layout>default</layout>


### PR DESCRIPTION
### Motivation
- Ensure Maven can resolve MuleSoft plugin artifacts by adding an additional public plugin repository to `pom.xml`.

### Description
- Added a new `<pluginRepository>` with id `mule-public` and URL `https://repository.mulesoft.org/nexus/content/repositories/releases` to the `pluginRepositories` section in `pom.xml`.

### Testing
- Verified the change by running `mvn -U package`; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f364e67928832a9133cbb0384c6736)